### PR TITLE
Sonde attribution to circle

### DIFF
--- a/flight_phase_files/HALO_RF02_20200122_info.yaml
+++ b/flight_phase_files/HALO_RF02_20200122_info.yaml
@@ -178,6 +178,7 @@ segments:
     - HALO-0122_s47
     - HALO-0122_s48
     BAD: []
+    - HALO-0122_s49
     UGLY: []
 - kinds:
   - circle_break
@@ -188,8 +189,7 @@ segments:
   end: 2020-01-22 20:59:01
   dropsondes:
     GOOD: []
-    BAD:
-    - HALO-0122_s49
+    BAD: []
     UGLY: []
 - kinds:
   - circle

--- a/flight_phase_files/HALO_RF14_20200215_info.yaml
+++ b/flight_phase_files/HALO_RF14_20200215_info.yaml
@@ -55,6 +55,7 @@ segments:
     - HALO-0215_s09
     - HALO-0215_s10
     - HALO-0215_s11
+    - HALO-0215_s12
     BAD: []
     UGLY: []
 - kinds:


### PR DESCRIPTION
Changes in sonde attribution to circle:

1. HALO-0215_s12 now part of c1 and c2 (preplanned as overlapping sonde for both circles)
2. HALO-0122_s49 now part of c5 instead of cb3