### PR TITLE
Sonde attribution to circle

### DIFF
--- a/flight_phase_files/HALO_RF06_20200130_info.yaml
+++ b/flight_phase_files/HALO_RF06_20200130_info.yaml
@@ -58,7 +58,8 @@ segments:
   start: 2020-01-30 12:08:42
   end: 2020-01-30 12:17:53
   dropsondes:
-    GOOD: []
+    GOOD: 
+    - HALO-0130_s02
     BAD: []
     UGLY: []
 - kinds:

--- a/flight_phase_files/HALO_RF06_20200130_info.yaml
+++ b/flight_phase_files/HALO_RF06_20200130_info.yaml
@@ -46,9 +46,9 @@ segments:
   start: 2020-01-30 11:55:38
   end: 2020-01-30 12:06:16
   dropsondes:
-    GOOD: []
-    BAD:
+    GOOD:
     - HALO-0130_s01
+    BAD: []
     UGLY: []
 - kinds:
   - straight_leg
@@ -91,9 +91,9 @@ segments:
   start: 2020-01-30 12:56:24
   end: 2020-01-30 13:13:21
   dropsondes:
-    GOOD: []
-    BAD:
+    GOOD:
     - HALO-0130_s03
+    BAD: []
     UGLY: []
 - kinds:
   - straight_leg
@@ -114,9 +114,9 @@ segments:
   start: 2020-01-30 13:35:10
   end: 2020-01-30 13:52:49
   dropsondes:
-    GOOD: []
-    BAD:
+    GOOD:
     - HALO-0130_s04
+    BAD: []
     UGLY: []
 - kinds:
   - straight_leg

--- a/sondes.yaml
+++ b/sondes.yaml
@@ -1254,7 +1254,7 @@
   launch_time: 2020-01-28 23:23:51
   platform: HALO
   sonde_id: HALO-0128_s74
-- flag: BAD
+- flag: GOOD
   launch_time: 2020-01-30 12:06:07
   platform: HALO
   sonde_id: HALO-0130_s01
@@ -1270,7 +1270,7 @@
   launch_time: 2020-01-30 13:35:57
   platform: HALO
   sonde_id: HALO-0130_s04
-- flag: GOOD
+- flag: BAD
   launch_time: 2020-01-31 15:21:57
   platform: HALO
   sonde_id: HALO-0131_s01


### PR DESCRIPTION
- correct sondes of HALO-0130 in sondes.yaml
- update these changes for the flight segment files of HALO-0130
- manually add sonde HALO-0130_s02 to segment HALO-0130_sl3