### PR TITLE
report: warning if irregularities are not strings

### DIFF
--- a/report.py
+++ b/report.py
@@ -229,6 +229,11 @@ class SegmentChecker:
                 yield "irregularities is not a list"
                 del seg["irregularities"]
                 irregularities = []
+            else:
+                if not all(isinstance(i, str) for i in irregularities):
+                    yield "irregularities is not a list of str"
+                    del seg["irregularities"]
+                    irregularities = []
         else:
             yield "segment has no irregularities attribute"
             irregularities = []


### PR DESCRIPTION
Some flight phase files don't provide strings as irregularities. This changes creates a warning for this case.