### PR TITLE
HALO-0124 and HALO-0126

### DIFF
--- a/flight_phase_files/HALO_RF03_20200124_info.yaml
+++ b/flight_phase_files/HALO_RF03_20200124_info.yaml
@@ -231,7 +231,8 @@ segments:
 - kinds:
   - circling
   name: circling 1
-  irregularities: []
+  irregularities: 
+  - TTFS HALO was already on the circle 147 s before first launch
   segment_id: HALO-0124_o1
   start: 2020-01-24 09:47:40
   end: 2020-01-24 16:56:30

--- a/flight_phase_files/HALO_RF03_20200124_info.yaml
+++ b/flight_phase_files/HALO_RF03_20200124_info.yaml
@@ -30,7 +30,7 @@ segments:
   - circle
   name: circle 1
   irregularities:
-  - late sonde from subsequent circle break is included here
+  - SAM late sonde from subsequent circle break is included here
   segment_id: HALO-0124_c1
   start: 2020-01-24 09:49:07
   end: 2020-01-24 10:46:26
@@ -55,7 +55,7 @@ segments:
   - circle_break
   name: circle break between circle 1 and circle 2
   irregularities:
-  - sonde was moved to circle 1
+  - SAM sonde was moved to previous segment, circle 1
   segment_id: HALO-0124_cb1
   start: 2020-01-24 10:46:26
   end: 2020-01-24 10:59:01
@@ -67,7 +67,8 @@ segments:
   - circle
   name: circle 2
   irregularities:
-  - late sonde from subsequent circle break is included here
+  - SAM late sonde from subsequent circle break is included here
+  - sudden jump in pitch in the final quarter of segment
   segment_id: HALO-0124_c2
   start: 2020-01-24 10:59:01
   end: 2020-01-24 11:56:59
@@ -92,7 +93,7 @@ segments:
   - circle_break
   name: circle break between circle 2 and circle 3
   irregularities:
-  - sonde was moved to circle 2
+  - SAM sonde was moved to previous segment, circle 2
   segment_id: HALO-0124_cb2
   start: 2020-01-24 11:56:59
   end: 2020-01-24 12:14:08
@@ -103,7 +104,8 @@ segments:
 - kinds:
   - circle
   name: circle 3
-  irregularities: []
+  irregularities: 
+  - higher roll fluctuation at the end of segment
   segment_id: HALO-0124_c3
   start: 2020-01-24 12:14:08
   end: 2020-01-24 13:13:30

--- a/flight_phase_files/HALO_RF03_20200124_info.yaml
+++ b/flight_phase_files/HALO_RF03_20200124_info.yaml
@@ -230,11 +230,11 @@ segments:
     UGLY: []
 - kinds:
   - circling
-  name: circling
+  name: circling 1
   irregularities: []
   segment_id: HALO-0124_o1
-  start: 2020-01-24 09:49:07
-  end: 2020-01-24 16:48:15
+  start: 2020-01-24 09:47:40
+  end: 2020-01-24 16:56:30
   dropsondes:
     GOOD:
     - HALO-0124_s01

--- a/flight_phase_files/HALO_RF04_20200126_info.yaml
+++ b/flight_phase_files/HALO_RF04_20200126_info.yaml
@@ -376,7 +376,7 @@ segments:
   - between circle 5 and 6, the flight deviated from the circle due to a traffic issue
   segment_id: HALO-0126_o3
   start: 2020-01-26 19:50:31
-  end: 2020-01-26 20:47:00
+  end: 2020-01-26 20:46:30
   dropsondes:
     GOOD:
     - HALO-0126_s64

--- a/flight_phase_files/HALO_RF04_20200126_info.yaml
+++ b/flight_phase_files/HALO_RF04_20200126_info.yaml
@@ -134,7 +134,8 @@ segments:
 - kinds:
   - circling
   name: circling 1
-  irregularities: []
+  irregularities: 
+  - TTFS 88 seconds to first launch as flight was already on circle path
   segment_id: HALO-0126_o1
   start: 2020-01-26 12:25:40
   end: 2020-01-26 15:40:30
@@ -312,10 +313,10 @@ segments:
   name: circle 6
   irregularities:
   - flight returned towards the island before completing a full circle
-  - circle end time denoted by change in altitude after last sonde
+  - circle end time denoted by significant change in roll after last sonde
   segment_id: HALO-0126_c6
   start: 2020-01-26 19:50:31
-  end: 2020-01-26 20:47:00
+  end: 2020-01-26 20:46:30
   dropsondes:
     GOOD:
     - HALO-0126_s64


### PR DESCRIPTION
- SAM and TTFS tags added to suppress warnings in reports
- Circling segment (o3) in HALO-0126 changed to adjust timestamp according to change in roll, rather than the previous change in altitude