### PR TITLE
RF11: TTFS and earlier circling

### DIFF
--- a/flight_phase_files/HALO_RF11_20200209_info.yaml
+++ b/flight_phase_files/HALO_RF11_20200209_info.yaml
@@ -322,7 +322,7 @@ segments:
     UGLY: []
 - kinds: [circling]
   name: circling 2
-  start: 2020-02-09 13:55:19
+  start: 2020-02-09 13:54:23
   end: 2020-02-09 17:24:26
   segment_id: HALO-0209_o2
   irregularities: []

--- a/flight_phase_files/HALO_RF11_20200209_info.yaml
+++ b/flight_phase_files/HALO_RF11_20200209_info.yaml
@@ -35,7 +35,7 @@ segments:
   end: 2020-02-09 10:32:49
   segment_id: HALO-0209_c1
   irregularities:
-  - begin is 34s before first launch due to roll angle at start
+  - TTFS begin is 34s before first launch due to roll angle at start
   dropsondes:
     GOOD:
     - HALO-0209_s01
@@ -100,7 +100,7 @@ segments:
   end: 2020-02-09 12:56:03
   segment_id: HALO-0209_c3
   irregularities:
-  - begin is 100s before first launch due to roll angle at end
+  - TTFS begin is 100s before first launch due to roll angle at end
   dropsondes:
     GOOD:
     - HALO-0209_s25
@@ -247,7 +247,7 @@ segments:
   end: 2020-02-09 17:24:26
   segment_id: HALO-0209_c6
   irregularities:
-  - begin is 362s before first launch due to roll angle at end
+  - TTFS begin is 362s before first launch due to roll angle at end
   dropsondes:
     GOOD:
     - HALO-0209_s61
@@ -280,7 +280,7 @@ segments:
   end: 2020-02-09 12:56:03
   segment_id: HALO-0209_o1
   irregularities:
-  - begin is 34s before first launch due to roll angle at start
+  - TTFS begin is 34s before first launch due to roll angle at start
   dropsondes:
     GOOD:
     - HALO-0209_s01


### PR DESCRIPTION
* Adjust circling to catch full circling periods --> For start and end exclude periods with large pitch
   * circling 2 could be started earlier
* Look through circles for significant changes in Flight Level and write irregularity where necessary
   * not found
* Add irregularity for cases where dropsondes are manually added to a circle of the form: “SAM <sonde_id>”
   * not needed
* For all “Time to first sonde” irregularities, add “TTFS” to start of the statements.
   * done